### PR TITLE
feat : #7 local graph db 구축 및 타법인출자 데이터 삽입

### DIFF
--- a/graphDB/neo4j_load_test.py
+++ b/graphDB/neo4j_load_test.py
@@ -1,0 +1,58 @@
+import os
+import json
+from neo4j import GraphDatabase
+from dotenv import load_dotenv
+
+load_dotenv()
+NEO4J_URI = os.getenv("NEO4J_URI")
+NEO4J_USER = os.getenv("NEO4J_USER")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD")
+
+EDGE_FILE = "../disclosure/타법인출자/output/otr_invest_edges_top30.json"
+
+
+def import_edges():
+    if not (NEO4J_URI and NEO4J_USER and NEO4J_PASSWORD):
+        raise RuntimeError(".env 설정오류")
+
+    with open(EDGE_FILE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    edges = data.get("edges", [])
+    print(f"불러온 edge 수: {len(edges)}")
+
+    driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
+
+    with driver.session() as session:
+        # DB 비우고 새로 넣고 싶으면 이 줄 주석 해제하기
+        # session.run("MATCH (n) DETACH DELETE n")
+
+        def _import_edge(tx, edge):
+            tx.run(
+                """
+                MERGE (s:Company {id: $source_id})
+                SET  s.name = $source_name
+
+                MERGE (t:Company {id: $target_id})
+                SET  t.name = $target_name
+
+                MERGE (s)-[r:INVESTS_IN {id: $edge_id}]->(t)
+                SET  r += $props
+                """,
+                source_id=edge["source"],
+                source_name=edge.get("source_name"),
+                target_id=edge["target"],
+                target_name=edge.get("target_name"),
+                edge_id=edge["id"],
+                props=edge.get("properties", {}),
+            )
+
+        for e in edges:
+            session.execute_write(_import_edge, e)
+
+    driver.close()
+    print("Neo4j 로 데이터 import 완료!")
+
+
+if __name__ == "__main__":
+    import_edges()


### PR DESCRIPTION
# ✨ 로컬 Neo4j 그래프 DB 구축 & 타법인출자 데이터 시각화

## 📌 요약
- 로컬 환경에서 그래프 DB를 구성함.
- KOSPI 시총 상위 30개 기업 기반으로 출자 관계 그래프를 Neo4j에 삽입하고 시각화 해봄

## 🧩 주요 변경 사항

### 1) 로컬 Neo4j 환경 구축
- Neo4j Desktop 설치 후 local database 생성

### 2) Neo4j 삽입 스크립트 작성 (neo4j_import_top30.py)

실행 후 Neo4j Browser에서 관계 및 노드 레이블 정상 생성 확인

### 3) 그래프 시각화 확인 결과


```MATCH (n)-[r]->(m) RETURN n, r, m```



<img width="1484" height="996" alt="image" src="https://github.com/user-attachments/assets/e12a1566-cc73-446a-8f40-e8c9aa0d255b" />
<img width="1484" height="996" alt="image" src="https://github.com/user-attachments/assets/9fbe8025-71ab-427c-99fe-16438afa212a" />

---
## ✏️ 리뷰 포인트

1. 어떤 기업들에 대해서 어떤 정보들을 잘 보여줄 수 있을지 구조를 설계하는 것이 중요해보임.
2. 타법인출자 데이터에 대해서는 purpose 가 중요하다고 판단하였음.
3. 3개년으로 데이터를 만들었지만, 똑같은 회사에 똑같은 이유로 매년마다 같은 데이터가 있는 경우도 있어서, 2025년도에 대해서만 데이터룰 수집하고 정제하여도 충분하다고 판단함. (데이터 필터링에 이러한 정보를 녹여서 보여주면 될 것 같음)
4. 데이터 db에 삽입하는데 시간이 20-30분(정확히 재보지는 않았지만) 정도 상당히 오래 걸리는 것으로 판단됨. 데이터를 나중에 db에 넣을 때 적은 데이터로 더 많은 정보를 효율적으로 보여줄 방법을 고민하는 것이 필요하다고 판단됨.