### PR TITLE
feat #6 : Add API call for equity investments and extract relationship data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 __pycache__/
 *.txt
 output/
+.github/
+*.xls
+*.json

--- a/company/.gitignore
+++ b/company/.gitignore
@@ -1,1 +1,3 @@
 *.json
+*.csv
+*.xls

--- a/disclosure/타법인출자/.gitignore
+++ b/disclosure/타법인출자/.gitignore
@@ -1,0 +1,3 @@
+*.json
+output/
+.env

--- a/disclosure/타법인출자/타법인출자.py
+++ b/disclosure/타법인출자/타법인출자.py
@@ -1,0 +1,259 @@
+import os
+import json
+import time
+import requests
+from tqdm import tqdm
+from dotenv import load_dotenv
+
+load_dotenv()
+DART_KEY = os.getenv("OPEN_DART_API_KEY")
+
+INPUT_CORP_FILE = "../company/corp_merged.json"
+RAW_OUTPUT_FILE = "./output/otr_invest_raw.json"
+EDGE_OUTPUT_FILE = "./output/otr_invest_edges.json"
+
+# 조회 연도
+YEARS = [2023, 2024, 2025]
+
+def call_dart_invest_api(corp_code: str, year: int):
+    """DART 타법인출자 API 호출"""
+    url = "https://opendart.fss.or.kr/api/otrCprInvstmntSttus.json"
+    params = {
+        "crtfc_key": DART_KEY,
+        "corp_code": corp_code,
+        "bsns_year": str(year),
+        "reprt_code": "11011",  # 사업보고서
+    }
+    resp = requests.get(url, params=params, timeout=10)
+    try:
+        return resp.json()
+    except Exception:
+        return {"status": "error", "message": "json parse error"}
+
+
+def has_valid_data(item: dict) -> bool:
+    """
+    '-'만 있는 더미 레코드인지 판단.
+    꽤 많은 회사가 '합계' / '-'만 있는 행을 반환하므로, 필터링 하였음
+    최소한 지분율이나 장부가액이 있는 경우만 '유효'로 봄.
+    """
+    if not item:
+        return False
+
+    if item.get("inv_prm") in ["", "-", None]:
+        return False
+
+    # 지분율이나 장부가에 뭔가 값이 있으면 '유효'
+    keys_to_check = [
+        "bsis_blce_qota_rt",
+        "trmend_blce_qota_rt",
+        "bsis_blce_acntbk_amount",
+        "trmend_blce_acntbk_amount",
+    ]
+
+    for k in keys_to_check:
+        v = item.get(k)
+        if v not in ["", "-", None, "0"]:
+            return True
+
+    return False
+
+
+def convert_amount(amount_str: str):
+    """
+    '1,234,000' → 1234000 (정수 변환).
+    필터링
+    """
+    if amount_str in ["", "-", None, " "]:
+        return None
+
+    s = str(amount_str).strip()
+
+    is_negative = False
+    if s.startswith("(") and s.endswith(")"):
+        is_negative = True
+        s = s[1:-1].strip()
+
+    s = s.replace(",", "")
+
+    if s.startswith(("+", "-")):
+        if s[0] == "-":
+            is_negative = True
+        s = s[1:].strip()
+        
+    if not s.isdigit():
+        return None
+
+    val = int(s)
+    return -val if is_negative else val
+
+
+def normalize_company_id(corp_code: str) -> str:
+    """그래프 노드 ID: KR_ + corp_code 형태로 생성"""
+    return f"KR_{corp_code}"
+
+
+def clean_name_for_match(name: str) -> str:
+    """매칭용 회사명 정규화: (주) 제외 """
+    if not name:
+        return ""
+    cleaned = (
+        name.replace("㈜", "")
+        .replace("(주)", "")
+        .replace("주식회사", "")
+        .strip()
+    )
+    return cleaned
+
+
+# -------------------------------
+
+def build_edge(
+    investor: dict,
+    investee_code: str | None,
+    investee_name_resolved: str | None,
+    row: dict,
+    year: int,
+    index: int,
+):
+    """
+    그래프용 출자 관계 edge 생성
+    investor: corp_merged.json 에서 온 회사 dict (name, corp_code 등)
+    investee_code: 매칭된 피투자사 corp_code (없으면 None)
+    investee_name_resolved: 매칭된 피투자사 이름 (없으면 None)
+    """
+    investor_id = normalize_company_id(investor["corp_code"])
+
+    if investee_code:
+        target_id = normalize_company_id(investee_code)
+        target_name = investee_name_resolved
+    else:
+        # DART에 있으나 corp_merged.json에 없는 케이스
+        raw_name = row.get("inv_prm", "")
+        target_id = f"UNRESOLVED_{raw_name}"
+        target_name = investee_name_resolved or raw_name
+
+    # 숫자 변환 (지분율)
+    try:
+        stake_ratio = (
+            float(row["trmend_blce_qota_rt"])
+            if row.get("trmend_blce_qota_rt") not in ["", "-", None]
+            else None
+        )
+    except (ValueError, TypeError):
+        stake_ratio = None
+
+    edge = {
+        "id": f"INV_{investor_id}_{year}_{index}",
+        "type": "INVESTOR_INVESTEE",
+        "source": investor_id,
+        "target": target_id,
+        "source_name": investor.get("name"),
+        "target_name": target_name,
+        "properties": {
+            "stake_ratio": stake_ratio,
+            "book_value": convert_amount(row.get("trmend_blce_acntbk_amount")),
+            "first_acq_date": row.get("frst_acqs_de"),
+            "purpose": row.get("invstmnt_purps"),
+            "acq_amount": convert_amount(row.get("frst_acqs_amount")),
+            "investee_name_raw": row.get("inv_prm"),
+            "as_of": row.get("stlm_dt"),
+            "bsns_year": year,
+            "rcept_no": row.get("rcept_no"),
+        },
+    }
+    return edge
+
+
+
+# -------------------------------
+
+def main():
+    if not DART_KEY:
+        raise RuntimeError("OPEN_DART_API_KEY 가 없음.")
+
+    with open(INPUT_CORP_FILE, "r", encoding="utf-8") as f:
+        companies = json.load(f)
+
+    # json 기업 이름 매칭
+    corp_name_to_code: dict[str, str] = {}
+    for c in companies:
+        name_clean = clean_name_for_match(c["name"])
+        if name_clean:
+            corp_name_to_code[name_clean] = c["corp_code"]
+
+    raw_results = []  # 원본 구조를 모으는 리스트
+    edges = []        # 그래프 edge 리스트
+
+    os.makedirs("./output", exist_ok=True)
+
+    print("\n전체 기업에 대해 2023~2025 타법인출자 관계 수집\n")
+
+    for comp in tqdm(companies):
+        investor_code = comp["corp_code"]
+        investor_name = comp["name"]
+
+        for year in YEARS:
+            try:
+                # DART API 호출
+                resp = call_dart_invest_api(investor_code, year)
+
+                if resp.get("status") != "000" or "list" not in resp:
+                    # 에러 또는 데이터 없음
+                    continue
+
+                rows = resp["list"]
+                valid_rows = [r for r in rows if has_valid_data(r)]
+
+                if not valid_rows:
+                    continue
+
+
+                raw_results.append(
+                    {
+                        "corp_code": investor_code,
+                        "corp_name": investor_name,
+                        "bsns_year": year,
+                        "reprt_code": "11011",
+                        "rows": valid_rows,
+                    }
+                )
+
+                
+                for idx, row in enumerate(valid_rows, start=1):
+                    raw_investee_name = row.get("inv_prm", "")
+                    investee_clean = clean_name_for_match(raw_investee_name)
+                    investee_code = corp_name_to_code.get(investee_clean)
+
+                    edge = build_edge(
+                        investor=comp,
+                        investee_code=investee_code,
+                        investee_name_resolved=investee_clean if investee_clean else None,
+                        row=row,
+                        year=year,
+                        index=idx,
+                    )
+                    edges.append(edge)
+
+                # 과도한 호출 방지용 딜레이 
+                time.sleep(0.1)
+
+            except Exception as e:
+                print(f"ERROR: {investor_name}({investor_code}) {year}년 처리 중 오류 → {e}")
+                continue
+
+    # -------------------------------
+    # 결과 저장
+    with open(RAW_OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump({"items": raw_results}, f, ensure_ascii=False, indent=2)
+
+    with open(EDGE_OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump({"edges": edges}, f, ensure_ascii=False, indent=2)
+
+    print("\n완료!")
+    print(f" - 유효 출자 원본 JSON: {len(raw_results)}개 회사/연도 → {RAW_OUTPUT_FILE}")
+    print(f" - 그래프 edge 개수: {len(edges)} → {EDGE_OUTPUT_FILE}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/disclosure/타법인출자/타법인출자_test_code.py
+++ b/disclosure/타법인출자/타법인출자_test_code.py
@@ -1,0 +1,150 @@
+import os
+import json
+import time
+import requests
+from pathlib import Path
+from typing import Dict, Any, List, Tuple
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_KEY = os.getenv("OPEN_DART_API_KEY")
+BASE_URL = "https://opendart.fss.or.kr/api/otrCprInvstmntSttus.json"
+
+MAX_COMPANIES = None  # 200 이런 식으로 제한해도 됨
+
+# 사업연도 / 보고서 코드
+BSNS_YEAR = "2023"       
+REPRT_CODE = "11011"      # 11011 = 사업보고서
+
+
+def load_corp_list(path: str) -> List[Tuple[str, str]]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    result = []
+    for item in data:
+        corp_code = item.get("corp_code")
+        name = item.get("name")
+        if corp_code and corp_code.strip():
+            result.append((corp_code.strip(), name or ""))
+
+    seen = set()
+    deduped = []
+    for corp_code, name in result:
+        if corp_code not in seen:
+            seen.add(corp_code)
+            deduped.append((corp_code, name))
+    return deduped
+
+
+def call_otr_api(corp_code: str, bsns_year: str, reprt_code: str) -> Dict[str, Any]:
+    """
+    타법인 출자현황 API 호출
+    """
+    params = {
+        "crtfc_key": API_KEY,
+        "corp_code": corp_code,
+        "bsns_year": bsns_year,
+        "reprt_code": reprt_code,
+    }
+    resp = requests.get(BASE_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def extract_valid_rows(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    - status=000
+    - list 안에서 inv_prm이 '-'나 '합계'가 아니고
+    - 지분율/금액이 전부 '-'가 아닌 row만 필터링
+    """
+    if data.get("status") != "000":
+        return []
+
+    rows = data.get("list") or []
+    valid = []
+
+    for item in rows:
+        inv_prm = item.get("inv_prm")  # 피투자회사명
+        qota_rt = item.get("trmend_blce_qota_rt")  # 기말 지분율
+        amount = item.get("trmend_blce_acntbk_amount")  # 기말 장부가액
+
+        if inv_prm in ("-", "합계") or not inv_prm:
+            continue
+        if (qota_rt in ("-", None, "")) and (amount in ("-", None, "")):
+            continue
+
+        valid.append(item)
+
+    return valid
+
+
+def main():
+    if not API_KEY:
+        raise RuntimeError("OPEN_DART_API_KEY 가 없음.")
+
+    corp_path = "corp_merged.json"  
+    corps = load_corp_list(corp_path)
+
+    total_corps = len(corps)
+    print(f"총 corp_code 개수: {total_corps}")
+    if MAX_COMPANIES is not None:
+        print(f"테스트 대상 상한: {MAX_COMPANIES}개 (실제: {min(total_corps, MAX_COMPANIES)}개)")
+
+    results = []  # 결과 데이터 
+    tested = 0
+    hit_count = 0
+
+    for corp_code, name in corps:
+        if MAX_COMPANIES is not None and tested >= MAX_COMPANIES:
+            break
+
+        tested += 1
+        try:
+            data = call_otr_api(corp_code, BSNS_YEAR, REPRT_CODE)
+        except Exception as e:
+            print(f"[ERROR] {name}({corp_code}) 호출 실패: {e}")
+            continue
+
+        valid_rows = extract_valid_rows(data)
+
+        if valid_rows:
+            hit_count += 1
+            print(
+                f"[HIT] {name}({corp_code}) - 유효 출자 row {len(valid_rows)}개"
+            )
+        
+            results.append(
+                {
+                    "corp_code": corp_code,
+                    "corp_name": name,
+                    "bsns_year": BSNS_YEAR,
+                    "reprt_code": REPRT_CODE,
+                    "rows": valid_rows,
+                }
+            )
+        else:
+            print(f"[EMPTY] {name}({corp_code}) - 유효 출자 데이터 없음")
+
+        # 너무 빠르게 호출하지 않도록 살짝 딜레이 
+        time.sleep(0.2)
+
+    # output 디렉토리 생성
+    out_dir = Path("output")
+    out_dir.mkdir(exist_ok=True)
+
+    out_path = out_dir / "타법인출자현황.json"
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+    print("\n=== 요약 ===")
+    print(f"- 테스트한 회사 수: {tested}")
+    print(f"- 실제 출자 데이터가 존재하는 회사 수: {hit_count}")
+    print(f"- 결과 파일: {out_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/disclosure/타법인출자/타법인출자top30.py
+++ b/disclosure/타법인출자/타법인출자top30.py
@@ -1,0 +1,60 @@
+import json
+
+INPUT_EDGE_FILE = "./output/otr_invest_edges.json"
+OUTPUT_EDGE_FILE = "./output/otr_invest_edges_top30.json"
+
+# 코스피 시총 Top 30 기업 이름 목록
+TOP30_NAMES = {
+    "삼성전자",
+    "SK하이닉스",
+    "LG에너지솔루션",
+    "삼성바이오로직스",
+    "한화에어로스페이스",
+    "KB금융",
+    "현대차",
+    "HD현대중공업",
+    "기아",
+    "셀트리온",
+    "두산에너빌리티",
+    "NAVER",
+    "한화오션",
+    "신한지주",
+    "삼성물산",
+    "삼성생명",
+    "카카오",
+    "HD한국조선해양",
+    "SK스퀘어",
+    "현대모비스",
+    "하나금융지주",
+    "현대로템",
+    "HMM",
+    "POSCO홀딩스",
+    "한국전력",
+    "HD현대일렉트릭",
+    "삼성화재",
+    "메리츠금융지주",
+    "LG화학",
+    "우리금융지주",
+}
+
+def main():
+    with open(INPUT_EDGE_FILE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    edges = data.get("edges", [])
+    
+    filtered_edges = [
+        e for e in edges 
+        if e.get("source_name") in TOP30_NAMES
+    ]
+
+    with open(OUTPUT_EDGE_FILE, "w", encoding="utf-8") as f:
+        json.dump({"edges": filtered_edges}, f, ensure_ascii=False, indent=2)
+
+    print("완료!")
+    print(f"- 전체 edge 개수: {len(edges)}")
+    print(f"- Top30 출발 edge 개수: {len(filtered_edges)}")
+    print(f"- 저장 위치: {OUTPUT_EDGE_FILE}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# ✨ PR: 타법인출자 데이터 수집, 정제 및 Top30 데이터 추출

## 📌 요약 

**DART 타법인출자 API 기반의 출자 관계 그래프 데이터 구축**  



## 🧩 주요 변경 사항

### 1. **타법인출자 전체 수집 스크립트 (`타법인출자.py`)**
- DART API(`otrCprInvstmntSttus.json`)를 연도별(2022023~2025) 호출하여 출자 현황 수집
- `corp_merged.json` 리스트 기반 전체 기업 반복 처리
- ‘-’, ‘합계’ 등 잘못된 row 제거 → **유효 출자 데이터만 저장**
- 숫자 문자열(장부가액 등) 정수 변환 처리
- 매칭된 기업은 `KR_{corp_code}`, 미매칭 기업은 `UNRESOLVED_{raw_name}` 형태 처리
- 이름 정규화 규칙
  - `㈜`, `(주)`, `주식회사` 제거  
  - 공백 제거  

- 출력 파일:
  - `otr_invest_raw.json` — 정제된 원본 구조
  - `otr_invest_edges.json` — Graph DB 입력용 edge 리스트



---

### 2. **테스트용 검증 코드 (`타법인출자_test_code.py`)**
- 단일 연도 기준 빠른 점검을 위한 테스트코드
- 회사별 유효 출자 데이터 존재 여부 출력
- 결과 파일: `타법인출자현황.json`

---

### 3. **Top30 출발 Edge 추출 코드 (`타법인출자top30.py`)**
- 필요한 기업만 뽑기 위해 코스피 시총 top 30 기준으로 이름 기반으로 해당 노드만 필터링하였음
- 출력 파일:
  - `otr_invest_edges_top30.json`

---
## ✏️ 참고

### 그래프 db 삽입을 위한 출자관계 Edge 구조 형식
예시
```json
{
  "id": "INV_KR_005930_2023_1",
  "type": "INVESTOR_INVESTEE",
  "source": "KR_005930",
  "target": "KR_123456",
  "source_name": "삼성전자",
  "target_name": "삼성물산",
  "properties": {
    "stake_ratio": 20.1,
    "book_value": 1234000000,
    "purpose": "단순투자",
    "acq_amount": 500000000,
    "investee_name_raw": "삼성물산",
    "as_of": "20231231",
    "bsns_year": 2023
  }
}
