### PR TITLE
feat #12 : 제3자배정 유상증자 이벤트 전체 파이프라인 구축

### DIFF
--- a/disclosure/증자자본/build_capital_increase_edges_clean.py
+++ b/disclosure/증자자본/build_capital_increase_edges_clean.py
@@ -1,0 +1,248 @@
+import json
+import os
+from typing import Any, Dict, List
+
+INPUT_PATH = "./output/capital_increase_third_party_full.json"
+OUTPUT_PATH = "./output/capital_increase_edges_clean.json"
+
+
+# 텍스트 유틸
+def norm(s: Any) -> str:
+    if s is None:
+        return ""
+    return " ".join(str(s).split()).strip()
+
+
+def is_hangul_name_like(text: str) -> bool:
+    """
+    아주 러프하게 '개인 이름 같아 보이는 문자열' 필터
+    - 공백 없음
+    - 길이 2~3
+    - 대부분이 한글
+    """
+    t = norm(text)
+    if not t:
+        return False
+    # 괄호/숫자/기호 날리기
+    for ch in "().,·-1234567890":
+        t = t.replace(ch, "")
+    t = t.strip()
+
+    if len(t) < 2 or len(t) > 3:
+        return False
+
+    # 한글 비율 체크
+    hangul_cnt = sum(1 for c in t if "가" <= c <= "힣")
+    return hangul_cnt >= len(t) * 0.8  # 거의 다 한글이면
+
+
+# 필터 룰
+CORP_KEYWORDS = [
+    "주식회사",
+    "㈜",
+    "유한회사",
+    "은행",
+    "증권",
+    "보험",
+    "자산운용",
+    "캐피탈",
+    "투자조합",
+    "신기술투자조합",
+    "벤처",
+    "파트너스",
+    "PEF",
+    "사모투자",
+]
+
+TRUSTEE_KEYWORDS = [
+    "신탁업자 지위에서",
+    "신탁업자의 지위에서",
+    "신탁업자 지위로",
+    "집합투자업자",
+    "수탁자",
+]
+
+RELATION_KEEP_KEYWORDS = [
+    "최대주주",
+    "주요주주",
+    "계열회사",
+    "관계회사",
+    "관계기업",
+    "자회사",
+    "종속회사",
+    "특수관계",
+    "전략적",
+    "업무",
+    "자본제휴",
+]
+
+RELATION_NOISE_EXACT = [
+    "-",
+    "없음",
+    "해당 없음",
+    "해당사항 없음",
+    "해당사항없음",
+    "해당사항 없음(주1)",
+    "해당사항없음.",
+    "개인",
+    "직원",
+    "임원",
+    "우리사주조합",
+    "소속근로자",
+]
+
+REMARK_BOOST_KEYWORDS = [
+    "의무보유",
+    "전환우선주",
+    "콜옵션",
+    "풋옵션",
+    "지분 인수",
+    "전략적",
+    "M&A",
+    "경영권",
+    "지배력",
+]
+
+
+def contains_any(text: str, keywords: List[str]) -> bool:
+    t = norm(text)
+    return any(k in t for k in keywords)
+
+
+def is_sum_row(name: str) -> bool:
+    # "계" 같은 합계 행
+    t = norm(name)
+    return t in ["계", "합계"]
+
+
+def is_trustee_like(name: str) -> bool:
+    return contains_any(name, TRUSTEE_KEYWORDS)
+
+
+def is_corporate_or_fund(name: str) -> bool:
+    return contains_any(name, CORP_KEYWORDS)
+
+
+def is_relation_noise(relation: str) -> bool:
+    t = norm(relation)
+    return t in RELATION_NOISE_EXACT
+
+
+def is_relation_interesting(relation: str) -> bool:
+    return contains_any(relation, RELATION_KEEP_KEYWORDS)
+
+
+def is_remark_or_reason_interesting(remark: str, reason: str) -> bool:
+    text = f"{norm(remark)} {norm(reason)}"
+    return contains_any(text, REMARK_BOOST_KEYWORDS)
+
+
+def should_keep_row(row: Dict[str, Any]) -> bool:
+    """
+    배정대상자 row를 그래프 엣지로 쓸지 말지 결정
+    """
+    name = norm(row.get("name"))
+    relation = norm(row.get("relation"))
+    reason = norm(row.get("reason"))
+    remark = norm(row.get("remark"))
+
+    if not name:
+        return False
+
+    # 1) 합계 행 제거
+    if is_sum_row(name):
+        return False
+
+    # 2) 신탁업자/집합투자업자 역할만 하는 경우 → 일단 노이즈로 처리
+    if is_trustee_like(name):
+        return False
+
+    # 3) 개인 이름처럼 보이고, relation도 노이즈 계열이면 버림
+    if is_hangul_name_like(name) and is_relation_noise(relation):
+        return False
+
+    # 4) 기업/펀드 키워드가 들어가면 그냥 keep
+    if is_corporate_or_fund(name):
+        return True
+
+    # 5) relation이 흥미로운 관계면 keep
+    if is_relation_interesting(relation):
+        return True
+
+    # 6) remark/reason에 의무보유/전환우선주 등 기재되어 있으면 keep
+    if is_remark_or_reason_interesting(remark, reason):
+        return True
+
+    # 그 외는 일단 버린다 
+    return False
+
+
+def parse_int_or_none(s: Any) -> int | None:
+    t = norm(s)
+    if not t or t in ["-", "해당없음", "해당 없음"]:
+        return None
+    try:
+        return int(t.replace(",", ""))
+    except ValueError:
+        return None
+
+
+# 메인 파이프라인
+def main():
+    if not os.path.exists(INPUT_PATH):
+        print(f"입력 파일을 찾을 수 없습니다: {INPUT_PATH}")
+        return
+
+    with open(INPUT_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    edges: List[Dict[str, Any]] = []
+
+    print(f"입력 이벤트 개수: {len(data)}")
+
+    for rec in data:
+        corp_code = rec.get("corp_code")
+        corp_name = rec.get("corp_name")
+        year = rec.get("year")
+        event = rec.get("event") or {}
+        rcept_no = event.get("rcept_no")
+
+        tables = rec.get("allocation_tables") or []
+        if not tables:
+            continue
+
+        for row in tables:
+            if not should_keep_row(row):
+                continue
+
+            name = norm(row.get("name"))
+
+            edge = {
+                "source_name": name,                 # 투자자 이름 (기업/펀드/기관/의미 있는 개인)
+                "target_corp_code": corp_code,       # 발행사
+                "target_corp_name": corp_name,
+                "relation_type": "CAPITAL_INCREASE_PARTICIPATION",
+                "meta": {
+                    "year": year,
+                    "rcept_no": rcept_no,
+                    "assigned_shares": parse_int_or_none(row.get("assigned_shares")),
+                    "assigned_shares_raw": norm(row.get("assigned_shares")),
+                    "relation_raw": norm(row.get("relation")),
+                    "reason": norm(row.get("reason")),
+                    "trade_history": norm(row.get("trade_history")),
+                    "remark": norm(row.get("remark")),
+                },
+            }
+
+            edges.append(edge)
+
+    # 저장
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(edges, f, ensure_ascii=False, indent=2)
+
+    print(f"완료! 최종 엣지 {len(edges)}개를 {OUTPUT_PATH} 에 저장했습니다.")
+
+
+if __name__ == "__main__":
+    main()

--- a/disclosure/증자자본/fetch_document_xml.py
+++ b/disclosure/증자자본/fetch_document_xml.py
@@ -1,16 +1,27 @@
 import io
+import os
 import zipfile
 import requests
 from dotenv import load_dotenv
-import os
+from typing import Optional
 
 load_dotenv()
 DART_KEY = os.getenv("OPEN_DART_API_KEY")
 
 DOC_URL = "https://opendart.fss.or.kr/api/document.xml"
 
-# document.xml API 호출 후 원본 파일 받아오기
-def fetch_document_xml(rcept_no: str) -> str | None:
+
+def fetch_document_xml(rcept_no: str) -> Optional[str]:
+    """
+    DART document.xml API 호출 유틸리티
+
+    처리 흐름:
+    1) API 호출
+    2) ZIP 응답이면 → XML 파일 추출
+    3) ZIP 아니면 → 텍스트(XML)로 디코딩 시도
+    4) 오류 응답이면 None 반환
+    """
+
     params = {
         "crtfc_key": DART_KEY,
         "rcept_no": rcept_no,
@@ -20,42 +31,49 @@ def fetch_document_xml(rcept_no: str) -> str | None:
         resp = requests.get(DOC_URL, params=params, timeout=20)
         resp.raise_for_status()
     except requests.exceptions.RequestException as e:
-        print(f"[WARN] document.xml 요청 실패: rcept_no={rcept_no}, 이유={e}")
+        print(f"document.xml 요청 실패: rcept_no={rcept_no}, 이유={e}")
         return None
 
     raw = resp.content
 
+
     try:
         with zipfile.ZipFile(io.BytesIO(raw)) as z:
-            names = z.namelist()
-            xml_candidates = [n for n in names if n.lower().endswith(".xml")]
-            if not xml_candidates:
+            xml_files = [n for n in z.namelist() if n.lower().endswith(".xml")]
+            if not xml_files:
                 return None
 
-            xml_name = xml_candidates[0]
-            xml_bytes = z.read(xml_name)
+            xml_bytes = z.read(xml_files[0])
 
         try:
-            xml_text = xml_bytes.decode("euc-kr")
+            return xml_bytes.decode("euc-kr")
         except UnicodeDecodeError:
-            xml_text = xml_bytes.decode("utf-8", errors="ignore")
-
-        return xml_text
+            return xml_bytes.decode("utf-8", errors="ignore")
 
     except zipfile.BadZipFile:
+        
+        pass
+
 
     try:
-        txt = raw.decode("euc-kr")
+        text = raw.decode("euc-kr")
     except UnicodeDecodeError:
-        txt = raw.decode("utf-8", errors="ignore")
+        text = raw.decode("utf-8", errors="ignore")
 
-    if "오류가 발생하였습니다" in txt or "접수번호 오류" in txt:
+    if "오류가 발생하였습니다" in text or "접수번호 오류" in text:
         return None
 
-    return txt
+    return text
 
-# xml 파일을 ./debug_docs 밑에 저장하는 함수
-def save_debug_xml(rcept_no: str, xml_text: str, corp_name: str | None = None):
+
+def save_debug_xml(
+    rcept_no: str,
+    xml_text: str,
+    corp_name: Optional[str] = None
+) -> None:
+    """
+    document.xml 원본을 debug_docs/ 아래에 저장 (디버깅 용도)
+    """
     os.makedirs("./debug_docs", exist_ok=True)
 
     safe_name = corp_name or "unknown"
@@ -68,20 +86,17 @@ def save_debug_xml(rcept_no: str, xml_text: str, corp_name: str | None = None):
         f.write(xml_text)
 
 
-
-
 if __name__ == "__main__":
     # 테스트
-    rcept_no = "20240802000202"  # 예시 문서 number
+    test_rcept_no = "20240802000202"
 
-    xml_text = fetch_document_xml(rcept_no)
+    xml_text = fetch_document_xml(test_rcept_no)
 
     if xml_text is None:
         print("document.xml 가져오기 실패")
     else:
-        print("document.xml 가져오기 성공, 앞 40줄만 출력\n")
-        lines = xml_text.splitlines()
-        for i, line in enumerate(lines[:40], start=1):
-            print(f"{i:03}: {line}")
+        # print("document.xml 가져오기 성공 (앞 40줄)\n")
+        # for i, line in enumerate(xml_text.splitlines()[:40], start=1):
+        #     print(f"{i:03}: {line}")
 
-        save_debug_xml(rcept_no, xml_text, corp_name="인투셀")
+        save_debug_xml(test_rcept_no, xml_text, corp_name="인투셀")

--- a/disclosure/증자자본/fetch_document_xml.py
+++ b/disclosure/증자자본/fetch_document_xml.py
@@ -1,0 +1,87 @@
+import io
+import zipfile
+import requests
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+DART_KEY = os.getenv("OPEN_DART_API_KEY")
+
+DOC_URL = "https://opendart.fss.or.kr/api/document.xml"
+
+# document.xml API 호출 후 원본 파일 받아오기
+def fetch_document_xml(rcept_no: str) -> str | None:
+    params = {
+        "crtfc_key": DART_KEY,
+        "rcept_no": rcept_no,
+    }
+
+    try:
+        resp = requests.get(DOC_URL, params=params, timeout=20)
+        resp.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"[WARN] document.xml 요청 실패: rcept_no={rcept_no}, 이유={e}")
+        return None
+
+    raw = resp.content
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as z:
+            names = z.namelist()
+            xml_candidates = [n for n in names if n.lower().endswith(".xml")]
+            if not xml_candidates:
+                return None
+
+            xml_name = xml_candidates[0]
+            xml_bytes = z.read(xml_name)
+
+        try:
+            xml_text = xml_bytes.decode("euc-kr")
+        except UnicodeDecodeError:
+            xml_text = xml_bytes.decode("utf-8", errors="ignore")
+
+        return xml_text
+
+    except zipfile.BadZipFile:
+
+    try:
+        txt = raw.decode("euc-kr")
+    except UnicodeDecodeError:
+        txt = raw.decode("utf-8", errors="ignore")
+
+    if "오류가 발생하였습니다" in txt or "접수번호 오류" in txt:
+        return None
+
+    return txt
+
+# xml 파일을 ./debug_docs 밑에 저장하는 함수
+def save_debug_xml(rcept_no: str, xml_text: str, corp_name: str | None = None):
+    os.makedirs("./debug_docs", exist_ok=True)
+
+    safe_name = corp_name or "unknown"
+    safe_name = "".join(c for c in safe_name if c.isalnum())
+
+    filename = f"document_{safe_name}_{rcept_no}.xml"
+    path = os.path.join("./debug_docs", filename)
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(xml_text)
+
+
+
+
+if __name__ == "__main__":
+    # 테스트
+    rcept_no = "20240802000202"  # 예시 문서 number
+
+    xml_text = fetch_document_xml(rcept_no)
+
+    if xml_text is None:
+        print("document.xml 가져오기 실패")
+    else:
+        print("document.xml 가져오기 성공, 앞 40줄만 출력\n")
+        lines = xml_text.splitlines()
+        for i, line in enumerate(lines[:40], start=1):
+            print(f"{i:03}: {line}")
+
+        save_debug_xml(rcept_no, xml_text, corp_name="인투셀")

--- a/disclosure/증자자본/fill_capital_increase_allocation_tables.py
+++ b/disclosure/증자자본/fill_capital_increase_allocation_tables.py
@@ -1,0 +1,199 @@
+"""
+[PIPELINE #2] (단순 버전) 제3자배정 이벤트 목록 → allocation_tables 채우기
+
+- 목적:
+  이미 수집된 제3자배정 이벤트(JSON)에 대해 document.xml을 재조회하여
+  배정대상자(THD_ASN_LST) 테이블을 allocation_tables로 채운다.
+
+- 입력:
+  - ./output/capital_increase_third_party_tables.json
+    (제3자배정 이벤트 메타만 있는 상태 / 또는 후보 테이블만 있는 상태)
+
+- 처리:
+  1) rcept_no로 document.xml 다운로드
+  2) ACLASS="THD_ASN_LST" 파싱 → allocation_tables 생성
+
+- 출력:
+  - ./output/capital_increase_third_party_table_with_alloc.json
+"""
+
+import os
+import io
+import json
+import time
+import zipfile
+import requests
+from typing import List, Dict, Any, Optional
+
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
+
+load_dotenv()
+DART_KEY = os.getenv("OPEN_DART_API_KEY")
+
+DOC_URL = "https://opendart.fss.or.kr/api/document.xml"
+INPUT_FILE = "./output/capital_increase_third_party_tables.json"
+OUTPUT_FILE = "./output/capital_increase_third_party_table_with_alloc.json"
+
+
+# ---------------------------
+# 1) document.xml 가져오기 (ZIP → XML)
+# ---------------------------
+def fetch_document_xml(rcept_no: str) -> Optional[str]:
+    """
+    document.xml API 호출 후:
+    1) resp.content를 ZIP으로 먼저 시도
+    2) BadZipFile이면 일반 텍스트(euc-kr → utf-8)로 디코딩 시도
+    """
+    params = {
+        "crtfc_key": DART_KEY,
+        "rcept_no": rcept_no,
+    }
+
+    try:
+        resp = requests.get(DOC_URL, params=params, timeout=20)
+        resp.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"[WARN] document.xml 요청 실패: rcept_no={rcept_no}, 이유={e}")
+        return None
+
+    raw = resp.content
+
+    # 1) ZIP 우선 시도
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as z:
+            names = z.namelist()
+            xml_candidates = [n for n in names if n.lower().endswith(".xml")]
+            if not xml_candidates:
+                print(f"[WARN] ZIP 안에 xml 파일 없음: rcept_no={rcept_no}, files={names}")
+                return None
+
+            xml_name = xml_candidates[0]
+            xml_bytes = z.read(xml_name)
+
+        try:
+            xml_text = xml_bytes.decode("euc-kr")
+        except UnicodeDecodeError:
+            xml_text = xml_bytes.decode("utf-8", errors="ignore")
+
+        return xml_text
+
+    except zipfile.BadZipFile:
+        # ZIP 아니면 일반 텍스트로
+        pass
+
+    # 2) 일반 텍스트 디코딩
+    try:
+        txt = raw.decode("euc-kr")
+    except UnicodeDecodeError:
+        txt = raw.decode("utf-8", errors="ignore")
+
+    if "오류가 발생하였습니다" in txt or "접수번호 오류" in txt:
+        print(f"[WARN] document.xml 응답 내 에러 문구 감지: rcept_no={rcept_no}")
+        return None
+
+    return txt
+
+
+# ---------------------------
+# 2) XML에서 제3자배정 '배정대상자 테이블' 파싱
+# ---------------------------
+def parse_third_party_allocation(xml_text: str) -> List[Dict[str, Any]]:
+    """
+    document.xml 안에서 ACLASS="THD_ASN_LST" 인 TABLE-GROUP을 찾아
+    제3자배정 '배정대상자' 테이블 파싱
+    """
+    soup = BeautifulSoup(xml_text, "lxml-xml")
+
+    tg = soup.find("TABLE-GROUP", {"ACLASS": "THD_ASN_LST"})
+    if tg is None:
+        return []
+
+    results: List[Dict[str, Any]] = []
+
+    for tr in tg.find_all("TR"):
+        row: Dict[str, Any] = {}
+
+        for cell in tr.find_all(["TE", "TU"]):
+            acode = cell.get("ACODE")
+            text = (cell.text or "").strip()
+
+            if acode == "PART":
+                row["name"] = text                 # 배정 대상자 명
+            elif acode == "RLT":
+                row["relation"] = text             # 관계
+            elif acode == "SLT_JDG":
+                row["reason"] = text               # 선정 경위
+            elif acode == "MNTH":
+                row["trade_history"] = text        # 6개월 내 거래내역
+            elif acode == "ALL_CNT":
+                row["assigned_shares"] = text      # 배정 주식수
+            elif acode == "ETC":
+                row["remark"] = text               # 비고
+
+        if "name" in row:
+            results.append(row)
+
+    return results
+
+
+# ---------------------------
+# 3) 기존 JSON을 읽어서 allocation_tables 채우기
+# ---------------------------
+def run_fill_allocation_tables():
+    # 1) 입력 JSON 로드
+    with open(INPUT_FILE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    print(f"입력 이벤트 개수: {len(data)}\n")
+
+    updated: List[Dict[str, Any]] = []
+
+    for idx, item in enumerate(data, start=1):
+        corp_code = item.get("corp_code")
+        corp_name = item.get("corp_name")
+        year = item.get("year")
+        event = item.get("event") or {}
+        rcept_no = event.get("rcept_no")
+
+        print("=" * 60)
+        print(f"({idx}/{len(data)}) {corp_name} ({corp_code}), year={year}")
+        print(f"  - rcept_no={rcept_no}")
+
+        # 이미 allocation_tables 가 채워져 있으면 스킵할 수도 있음 (원하면 조건 추가)
+        # if item.get("allocation_tables"):
+        #     print("  → 이미 allocation_tables 존재, 스킵\n")
+        #     updated.append(item)
+        #     continue
+
+        if not rcept_no:
+            print("  → rcept_no 없음, 스킵\n")
+            updated.append(item)
+            continue
+
+        xml_text = fetch_document_xml(rcept_no)
+        time.sleep(1.0)  
+
+        if xml_text is None:
+            print(" → document.xml 가져오기 실패, allocation_tables 비워둠\n")
+            item["allocation_tables"] = []
+            updated.append(item)
+            continue
+
+        allocations = parse_third_party_allocation(xml_text)
+        print(f" → 제3자배정 배정대상자 {len(allocations)}명 추출")
+
+        item["allocation_tables"] = allocations
+        updated.append(item)
+        print()
+
+    # 2) 결과 저장
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump(updated, f, ensure_ascii=False, indent=2)
+
+    print("\n완료!")
+    print(f"   → 저장 파일: {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    run_fill_allocation_tables()

--- a/disclosure/증자자본/fill_capital_increase_allocation_tables_checkpoint.py
+++ b/disclosure/증자자본/fill_capital_increase_allocation_tables_checkpoint.py
@@ -1,0 +1,259 @@
+"""
+- 목적:
+  제3자배정 이벤트 목록(JSON)을 기반으로 document.xml을 재조회하고,
+  배정대상자(THD_ASN_LST) 테이블을 파싱하여 allocation_tables를 채운다.
+  중간에 끊겨도 복구 가능하도록 partial 파일을 매번 저장한다.
+
+- 입력:
+  - ./output/capital_increase_third_party_tables.json
+
+- 처리:
+  1) rcept_no로 document.xml(zip/xml) 다운로드
+  2) THD_ASN_LST 파싱
+  3) 합계/소계 행 등 노이즈 행 제거
+  4) 매 이벤트마다 partial 파일 저장 (checkpoint)
+
+- 출력:
+  - ./output/capital_increase_third_party_table_with_alloc.partial.json (checkpoint)
+  - ./output/capital_increase_third_party_table_with_alloc.json (final)
+"""
+
+import os
+import io
+import json
+import time
+import zipfile
+import requests
+from typing import List, Dict, Any, Optional
+
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
+
+load_dotenv()
+DART_KEY = os.getenv("OPEN_DART_API_KEY")
+
+DOC_URL = "https://opendart.fss.or.kr/api/document.xml"
+
+INPUT_FILE = "./output/capital_increase_third_party_tables.json"
+OUTPUT_FILE = "./output/capital_increase_third_party_table_with_alloc.json"
+PARTIAL_FILE = "./output/capital_increase_third_party_table_with_alloc.partial.json"
+
+
+def fetch_document_xml(rcept_no: str) -> Optional[str]:
+    """
+    document.xml API 호출 후:
+    1) resp.content를 ZIP으로 먼저 시도
+    2) BadZipFile이면 일반 텍스트(euc-kr → utf-8)로 디코딩 시도
+    """
+    params = {
+        "crtfc_key": DART_KEY,
+        "rcept_no": rcept_no,
+    }
+
+    try:
+        resp = requests.get(DOC_URL, params=params, timeout=20)
+        resp.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"[WARN] document.xml 요청 실패: rcept_no={rcept_no}, 이유={e}")
+        return None
+
+    raw = resp.content
+
+    # 1) ZIP 우선 시도
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as z:
+            names = z.namelist()
+            xml_candidates = [n for n in names if n.lower().endswith(".xml")]
+            if not xml_candidates:
+                print(f"[WARN] ZIP 안에 xml 파일 없음: rcept_no={rcept_no}, files={names}")
+                return None
+
+            xml_name = xml_candidates[0]
+            xml_bytes = z.read(xml_name)
+
+        try:
+            xml_text = xml_bytes.decode("euc-kr")
+        except UnicodeDecodeError:
+            xml_text = xml_bytes.decode("utf-8", errors="ignore")
+
+        return xml_text
+
+    except zipfile.BadZipFile:
+        # ZIP 아니면 일반 텍스트로
+        pass
+
+    # 2) 일반 텍스트 디코딩
+    try:
+        txt = raw.decode("euc-kr")
+    except UnicodeDecodeError:
+        txt = raw.decode("utf-8", errors="ignore")
+
+    if "오류가 발생하였습니다" in txt or "접수번호 오류" in txt:
+        print(f"[WARN] document.xml 응답 내 에러 문구 감지: rcept_no={rcept_no}")
+        return None
+
+    return txt
+
+
+# ---------------------------
+# 2) XML에서 제3자배정 '배정대상자 테이블' 파싱 (+ 합계행 필터링)
+# ---------------------------
+def parse_third_party_allocation(xml_text: str) -> List[Dict[str, Any]]:
+    """
+    document.xml 안에서 ACLASS="THD_ASN_LST" 인 TABLE-GROUP을 찾아
+    제3자배정 '배정대상자' 테이블 파싱
+
+    반환 값 예시:
+    [
+      {
+        "name": "광혁건설",
+        "relation": "관계없음",
+        "reason": "...",
+        "trade_history": "...",
+        "assigned_shares": "176,470",
+        "remark": "-"
+      },
+      ...
+    ]
+    """
+    soup = BeautifulSoup(xml_text, "lxml-xml")
+
+    tg = soup.find("TABLE-GROUP", {"ACLASS": "THD_ASN_LST"})
+    if tg is None:
+        return []
+
+    raw_rows: List[Dict[str, Any]] = []
+
+    for tr in tg.find_all("TR"):
+        row: Dict[str, Any] = {}
+
+        for cell in tr.find_all(["TE", "TU"]):
+            acode = cell.get("ACODE")
+            text = (cell.text or "").strip()
+
+            if acode == "PART":
+                row["name"] = text                 # 배정 대상자 명
+            elif acode == "RLT":
+                row["relation"] = text             # 관계
+            elif acode == "SLT_JDG":
+                row["reason"] = text               # 선정 경위
+            elif acode == "MNTH":
+                row["trade_history"] = text        # 6개월 내 거래내역
+            elif acode == "ALL_CNT":
+                row["assigned_shares"] = text      # 배정 주식수
+            elif acode == "ETC":
+                row["remark"] = text               # 비고
+
+        # 최소한 name 이 있는 행만 유효한 데이터로 본다 (헤더/빈 행 제거)
+        if "name" in row:
+            # 공백 정리
+            row["name"] = (row.get("name") or "").strip()
+            row["relation"] = (row.get("relation") or "").strip() or None
+            row["reason"] = (row.get("reason") or "").strip() or None
+            row["trade_history"] = (row.get("trade_history") or "").strip() or None
+            row["assigned_shares"] = (row.get("assigned_shares") or "").strip() or None
+            row["remark"] = (row.get("remark") or "").strip() or None
+
+            raw_rows.append(row)
+
+    # 합계 행(계/합계/소계 등) 필터링
+    cleaned: List[Dict[str, Any]] = []
+    for row in raw_rows:
+        name = (row.get("name") or "").strip()
+        relation = (row.get("relation") or "").strip() if row.get("relation") else ""
+        reason = (row.get("reason") or "").strip() if row.get("reason") else ""
+        trade_history = (row.get("trade_history") or "").strip() if row.get("trade_history") else ""
+
+        # 합계/소계/계 등으로 보이는 행 여부
+        is_total_like = (
+            name in ("계", "합계", "소계")
+            or name.endswith(" 계")
+            or name.endswith(" 합계")
+            or name.endswith(" 소계")
+        )
+
+        # 내용이 거의 없는 경우(모두 '-' 이거나 빈값)
+        mostly_empty = all(
+            v in ("", "-", None)
+            for v in [relation, reason, trade_history]
+        )
+
+        if is_total_like and mostly_empty:
+            # 합계 행이므로 스킵
+            continue
+
+        cleaned.append(row)
+
+    return cleaned
+
+
+# ---------------------------
+# 3) 전체 JSON을 돌면서 allocation_tables 채우기
+# ---------------------------
+def run_fill_allocation_tables():
+    # 1) 입력 JSON 로드
+    with open(INPUT_FILE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    total = len(data)
+    print(f"입력 이벤트 개수: {total}\n")
+
+    updated: List[Dict[str, Any]] = []
+
+    # 혹시 PARTIAL_FILE 이 이미 있으면, 재시도 시 이어서 쓸 수도 있음
+    # (지금은 간단하게 무시하고 새로 도는 형태로 둠)
+    # 필요하면 여기서 로드 로직 추가해도 됨.
+
+    for idx, item in enumerate(data, start=1):
+        corp_code = item.get("corp_code")
+        corp_name = item.get("corp_name")
+        year = item.get("year")
+        event = item.get("event") or {}
+        rcept_no = event.get("rcept_no")
+
+        print("=" * 60)
+        print(f"({idx}/{total}) {corp_name} ({corp_code}), year={year}")
+        print(f"  - rcept_no={rcept_no}")
+
+        if not rcept_no:
+            print("  → rcept_no 없음, allocation_tables 비움\n")
+            item["allocation_tables"] = []
+            updated.append(item)
+        else:
+            xml_text = fetch_document_xml(rcept_no)
+            time.sleep(1.0)  # API 부하 방지 
+
+            if xml_text is None:
+                print("  → document.xml 가져오기 실패, allocation_tables 비워둠\n")
+                item["allocation_tables"] = []
+                updated.append(item)
+            else:
+                try:
+                    allocations = parse_third_party_allocation(xml_text)
+                    print(f"  → 제3자배정 배정대상자 {len(allocations)}명 추출 (합계 행 제거 후)")
+                except Exception as e:
+                    print(f"[WARN] XML 파싱 중 오류 발생: rcept_no={rcept_no}, 이유={e}")
+                    allocations = []
+
+                item["allocation_tables"] = allocations
+                updated.append(item)
+                print()
+
+        # 매 건마다 PARTIAL_FILE로 중간 저장해서, 중간에 끊겨도 여기까지 남도록
+        try:
+            with open(PARTIAL_FILE, "w", encoding="utf-8") as pf:
+                json.dump(updated, pf, ensure_ascii=False, indent=2)
+        except Exception as e:
+            print(f"[WARN] PARTIAL_FILE 저장 실패: {e}")
+
+    # 2) 전체 완료 후 최종 파일로 저장
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump(updated, f, ensure_ascii=False, indent=2)
+
+    print("\n전체 처리 완료!")
+    print(f"   → 중간 결과(백업): {PARTIAL_FILE}")
+    print(f"   → 최종 결과: {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    run_fill_allocation_tables()

--- a/disclosure/증자자본/make_capital_increase_third_party_tables.py
+++ b/disclosure/증자자본/make_capital_increase_third_party_tables.py
@@ -1,0 +1,180 @@
+import os
+import json
+import time
+import requests
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
+
+load_dotenv()
+DART_KEY = os.getenv("OPEN_DART_API_KEY")
+
+DOC_URL = "https://opendart.fss.or.kr/api/document.xml"
+PIIC_INPUT_PATH = "./output/piic_top100_details.json"
+OUTPUT_PATH = "./output/capital_increase_third_party_tables.json"
+
+# results 리스트를 JSON으로 안전하게 저장
+def save_results_safely(results, path: str):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp_path = path + ".tmp"
+
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+    os.replace(tmp_path, path)
+
+# 공백, 줄바꿈 제거
+def normalize_text(s: str) -> str:
+    if s is None:
+        return ""
+    return " ".join(str(s).split())
+
+
+# document.xml 원문 문자열로 반환
+def fetch_document_xml(rcept_no: str) -> str | None:
+    params = {
+        "crtfc_key": DART_KEY,
+        "rcept_no": rcept_no,
+    }
+
+    try:
+        resp = requests.get(DOC_URL, params=params, timeout=15)
+        resp.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"[WARN] document.xml 요청 실패: rcept_no={rcept_no}, 이유={e}")
+        return None
+
+    txt = resp.text
+    if "접수번호 오류" in txt or "오류가 발생하였습니다" in txt:
+        print(f"document.xml 응답 내 에러 문구 감지: rcept_no={rcept_no}")
+        return None
+
+    return txt
+
+
+#  테이블 파싱
+KEYWORDS = ["배정대상자", "청약배정대상", "배정 내역", "배정내역", "배정방법", "배정 방식"]
+
+def extract_candidate_tables(xml_text: str):
+    """
+    document.xml 에서 '배정대상자' 관련 테이블만 추려서 파싱.
+    - 키워드가 포함된 table만 대상으로 함.
+    - 각 table을 header / rows 형태로 구조화해서 반환.
+    """
+    soup = BeautifulSoup(xml_text, "lxml-xml")
+    tables = soup.find_all("table")
+    parsed_tables = []
+
+    for idx, table in enumerate(tables):
+        table_text = " ".join(list(table.stripped_strings))
+        if not any(k in table_text for k in KEYWORDS):
+            continue
+
+        rows = []
+        for tr in table.find_all("tr"):
+            cells = tr.find_all(["th", "td"])
+            cell_texts = [normalize_text(c.get_text(separator=" ", strip=True)) for c in cells]
+            # 완전히 빈 줄은 스킵
+            if any(cell_texts):
+                rows.append(cell_texts)
+
+        if not rows:
+            continue
+
+        header = rows[0]
+        body_rows = rows[1:] if len(rows) > 1 else []
+
+        parsed_tables.append(
+            {
+                "table_index": idx,
+                "header": header,
+                "rows": body_rows,
+                # 디버깅
+                "preview_text": table_text[:300],
+            }
+        )
+
+    return parsed_tables
+
+
+def main():
+    with open(PIIC_INPUT_PATH, "r", encoding="utf-8") as f:
+        piic_data = json.load(f)
+
+    results = []
+    already_processed_rcept = set()
+
+    if os.path.exists(OUTPUT_PATH):
+        try:
+            with open(OUTPUT_PATH, "r", encoding="utf-8") as f:
+                results = json.load(f)
+            for rec in results:
+                already_processed_rcept.add(rec["rcept_no"])
+            print(f"기존 결과 {len(results)}개 불러옴 (rcept_no {len(already_processed_rcept)}개)")
+        except Exception:
+            print("기존 결과 읽기 실패 ")
+            results = []
+            already_processed_rcept = set()
+
+    print("\n제3자배정(third_party=True) 이벤트에 대해 document.xml 파싱 시작\n")
+
+    for corp in piic_data:
+        corp_code = corp.get("corp_code")
+        corp_name = corp.get("corp_name")
+
+        for ev in corp.get("events", []):
+            if not ev.get("third_party"):
+                continue  # 제3자배정 아닌 건 스킵
+
+            rcept_no = ev.get("rcept_no")
+            ic_mthn = ev.get("ic_mthn")
+
+            if not rcept_no:
+                continue
+
+            if rcept_no in already_processed_rcept:
+                # 이미 저장된 접수번호면 스킵
+                continue
+
+            print(f"{corp_name} ({corp_code}), rcept_no={rcept_no}, 방법={ic_mthn}")
+
+            # 1. document.xml 가져오기
+            xml_text = fetch_document_xml(rcept_no)
+            if not xml_text:
+                print(f"document.xml 없음 / 에러로 스킵")
+                time.sleep(0.3)
+                continue
+
+            # 2. 배정대상자 관련 테이블 파싱
+            tables = extract_candidate_tables(xml_text)
+            if not tables:
+                print(f"'배정대상자' 관련 테이블 찾지 못함")
+            else:
+                print(f"후보 테이블 {len(tables)}개 발견")
+
+            # 3. 결과 구조 만들기
+            result_rec = {
+                "corp_code": corp_code,
+                "corp_name": corp_name,
+                "year": corp.get("year"),  
+                "event": {
+                    "rcept_no": rcept_no,
+                    "ic_mthn": ic_mthn,
+                    "third_party": ev.get("third_party"),
+                    "raw_event": ev, 
+                },
+                "allocation_tables": tables,
+            }
+
+            results.append(result_rec)
+            already_processed_rcept.add(rcept_no)
+
+            save_results_safely(results, OUTPUT_PATH)
+
+            # DART 호출 너무 빠르게 안 하도록 딜레이
+            time.sleep(0.5)
+
+    print(f"\n끝 - 총 {len(results)}개 제3자배정 이벤트에 대한 document.xml 테이블이 {OUTPUT_PATH}에 저장되었습니다.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/disclosure/증자자본/make_piic_top100_details_json.py
+++ b/disclosure/증자자본/make_piic_top100_details_json.py
@@ -126,9 +126,7 @@ def main():
 
             if total_cnt >= 1:
                 if not found_any_for_corp:
-                    print("\n==============================")
                     print(f"{corp_name} ({corp_code})")
-                    print("==============================")
                     found_any_for_corp = True
 
                 print(f"- {year}: 전체 {total_cnt}건 (제3자배정 {third_cnt}건)")

--- a/disclosure/증자자본/make_piic_top100_details_json.py
+++ b/disclosure/증자자본/make_piic_top100_details_json.py
@@ -1,0 +1,155 @@
+import json
+import time
+import os
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+DART_KEY = os.getenv("OPEN_DART_API_KEY")
+PIIC_URL = "https://opendart.fss.or.kr/api/piicDecsn.json"
+OUTPUT_PATH = "./output/piic_top100_details.json"
+
+# 중간에 끊기거나 에러가 나도 정상적으로 저장
+def save_results_safely(results, path: str):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp_path = path + ".tmp"
+
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+    os.replace(tmp_path, path)
+
+# 유상증자 결정 API 호출 
+def fetch_piic_list(corp_code: str, bgn_de: str, end_de: str):
+    params = {
+        "crtfc_key": DART_KEY,
+        "corp_code": corp_code,
+        "bgn_de": bgn_de,
+        "end_de": end_de,
+    }
+
+    try:
+        r = requests.get(PIIC_URL, params=params, timeout=10)
+    except requests.exceptions.RequestException as e:
+        print("error")
+        return []
+
+    try:
+        data = r.json()
+    except Exception:
+        print(f"JSON 파싱 실패: corp={corp_code}, 기간={bgn_de}~{end_de}")
+        return []
+
+    status = data.get("status")
+    msg = data.get("message")
+
+    if status == "000":
+        return data.get("list", [])
+
+    elif status == "013":
+        # 조회건수 0 →
+        return []
+
+    else:
+        print(f"piicDecsn error {status}: {msg}")
+        return []
+
+# dart piicDecsn list를 우리가 쓰기 좋은 형태로 정규화
+def normalize_piic_events(piic_list):
+    events = []
+
+    for row in piic_list:
+        ic_mthn = (row.get("ic_mthn") or "").strip()  # 증자방법 (제3자배정, 주주배정 등)
+        third_party = "제3자배정" in ic_mthn
+
+        event = {
+            "rcept_no": row.get("rcept_no"),
+            "ic_mthn": ic_mthn,
+            "isu_de": row.get("isu_de"),          # 발행일
+            "isu_knd": row.get("isu_knd"),        # 발행 주식 종류
+            "isu_prc": row.get("isu_prc"),        # 발행가
+            "isu_qy": row.get("isu_qy"),          # 발행 주식 수
+            "evl_bss": row.get("evl_bss"),        # 평가 기준
+            "third_party": third_party,           # 제3자배정 여부
+            "raw": row,                           # 원본 row 전체
+        }
+        events.append(event)
+
+    return events
+
+
+def main():
+    results = []
+    if os.path.exists(OUTPUT_PATH):
+        try:
+            with open(OUTPUT_PATH, "r", encoding="utf-8") as f:
+                results = json.load(f)
+            print(f"기존 결과 {len(results)}개 불러옴: {OUTPUT_PATH}")
+        except Exception:
+            print("기존 파일 읽기 실패")
+            results = []
+
+    already_done = {(r["corp_code"], r["year"]) for r in results}
+
+    with open("company_list_market.json", "r", encoding="utf-8") as f:
+        companies = json.load(f)
+
+    target_list = companies[:100]
+
+    print(f"총 {len(target_list)}개 기업 처리 시작\n")
+
+    for comp in target_list:
+        corp_name = comp.get("name")
+        corp_code = comp.get("corp_code")
+
+        if not corp_code:
+            continue
+
+        found_any_for_corp = False
+
+        # 2019년부터 2025년까지 유상증자 결정 데이터 조회
+        for year in range(2019, 2025 + 1):
+            if (corp_code, year) in already_done:
+                continue
+
+            bgn_de = f"{year}0101"
+            end_de = f"{year}1231"
+
+            piic_list = fetch_piic_list(corp_code, bgn_de, end_de)
+            if not piic_list:
+                time.sleep(0.2)
+                continue
+
+            events = normalize_piic_events(piic_list)
+            total_cnt = len(events)
+            third_cnt = sum(1 for e in events if e["third_party"])
+
+            if total_cnt >= 1:
+                if not found_any_for_corp:
+                    print("\n==============================")
+                    print(f"{corp_name} ({corp_code})")
+                    print("==============================")
+                    found_any_for_corp = True
+
+                print(f"- {year}: 전체 {total_cnt}건 (제3자배정 {third_cnt}건)")
+
+                record = {
+                    "corp_code": corp_code,
+                    "corp_name": corp_name,
+                    "year": year,
+                    "total_count": total_cnt,
+                    "third_party_count": third_cnt,
+                    "events": events,
+                }
+                results.append(record)
+                already_done.add((corp_code, year))
+
+                save_results_safely(results, OUTPUT_PATH)
+
+            time.sleep(0.2)
+
+    print(f"완료! 총 {len(results)}개 (corp_code, year) 결과가 {OUTPUT_PATH}에 저장되었습니다.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/disclosure/증자자본/relation_keyword.py
+++ b/disclosure/증자자본/relation_keyword.py
@@ -1,0 +1,28 @@
+# .output/capital_increase_third_party_full.json에서 의미있는 관계가 있나 확인하기 위해 relation 유니크한 키워드만 추출하고자 한다
+import json
+
+INPUT_PATH = "./output/capital_increase_third_party_full.json"
+
+def extract_unique_relations(path):
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    relations = set()
+
+    for item in data:
+        allocs = item.get("allocation_tables", [])
+        for row in allocs:
+            rel = row.get("relation")
+            if rel:
+                relations.add(rel.strip())
+
+    return sorted(relations)
+
+
+if __name__ == "__main__":
+    unique_relations = extract_unique_relations(INPUT_PATH)
+
+    print("총 relation 종류:", len(unique_relations))
+    print("=====================================")
+    for r in unique_relations:
+        print(r)

--- a/disclosure/증자자본/scan_all_listed_third_party_allocation.py
+++ b/disclosure/증자자본/scan_all_listed_third_party_allocation.py
@@ -1,0 +1,333 @@
+"""
+[PIPELINE #1] 전체 상장사 제3자배정 유상증자 풀 스캔 → 원천 데이터 생성기
+
+- 입력:
+  - company_list_market.json (상장사 목록)
+- 처리:
+  1) piicDecsn(유상증자결정) 연도별 조회
+  2) "제3자배정" 이벤트만 필터링
+  3) document.xml(zip/xml) 다운로드
+  4) ACLASS="THD_ASN_LST" 배정대상자 테이블 파싱 → allocation_tables 생성
+- 출력:
+  - ./output/capital_increase_third_party_full.json
+    (각 이벤트별 배정대상자 테이블이 채워진 원천 데이터)
+"""
+
+import os
+import io
+import json
+import time
+import zipfile
+from typing import List, Dict, Any, Optional, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
+
+# ==========================
+#  환경변수 & 상수 설정
+# ==========================
+load_dotenv()
+DART_KEY = os.getenv("OPEN_DART_API_KEY")
+
+if not DART_KEY:
+    raise RuntimeError("OPEN_DART_API_KEY 가 .env 에 설정되어 있지 않습니다.")
+
+PIIC_URL = "https://opendart.fss.or.kr/api/piicDecsn.json"
+DOC_URL = "https://opendart.fss.or.kr/api/document.xml"
+
+COMPANY_FILE = "company_list_market.json"
+OUTPUT_PATH = "./output/capital_increase_third_party_full.json"
+# 연도설정
+YEARS = list(range(2022, 2025 + 1))
+API_SLEEP_SEC = 0.25
+
+
+# results 리스트를 JSON으로 안전하게 저장
+def save_results_safely(results: List[Dict[str, Any]], path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp_path = path + ".tmp"
+
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+    os.replace(tmp_path, path)
+
+
+def normalize_text(s: Optional[str]) -> str:
+    """공백 / 줄바꿈 정리용"""
+    if s is None:
+        return ""
+    return " ".join(str(s).split())
+
+
+# piicDecsn 조회
+def fetch_piic_list(corp_code: str, bgn_de: str, end_de: str) -> List[Dict[str, Any]]:
+    params = {
+        "crtfc_key": DART_KEY,
+        "corp_code": corp_code,
+        "bgn_de": bgn_de,
+        "end_de": end_de,
+    }
+
+    try:
+        r = requests.get(PIIC_URL, params=params, timeout=10)
+    except requests.exceptions.RequestException as e:
+        print(f"piicDecsn 요청 실패: corp={corp_code}, 기간={bgn_de}~{end_de}")
+        print(f"       이유: {e}")
+        return []
+
+    try:
+        data = r.json()
+    except Exception:
+        print(f"JSON 파싱 실패: corp={corp_code}, 기간={bgn_de}~{end_de}")
+        print("       raw text (앞 200자):", r.text[:200])
+        return []
+
+    status = data.get("status")
+    msg = data.get("message")
+
+    if status == "000":
+        return data.get("list", []) or []
+
+    elif status == "013":
+        # 조회건수 0 → 정상적으로 "없는 것"
+        return []
+
+    else:
+        print(f"[ERROR] piicDecsn error {status}: {msg}")
+        print("URL:", r.url)
+        return []
+
+
+def normalize_piic_events(piic_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    events: List[Dict[str, Any]] = []
+
+    for row in piic_list:
+        ic_mthn = (row.get("ic_mthn") or "").strip()
+        third_party = "제3자배정" in ic_mthn
+
+        event = {
+            # 나중에 document.xml 호출용
+            "rcept_no": row.get("rcept_no"),
+            # 증자 방법 설명
+            "ic_mthn": ic_mthn,
+            "isu_de": row.get("isu_de"),      # 발행일 (없으면 None)
+            "isu_knd": row.get("isu_knd"),    # 발행 주식 종류
+            "isu_prc": row.get("isu_prc"),    # 발행가
+            "isu_qy": row.get("isu_qy"),      # 발행 주식 수
+            "evl_bss": row.get("evl_bss"),    # 평가 기준
+            "third_party": third_party,       # 제3자배정 여부
+            "raw": row,                       # 원본 전체
+        }
+        events.append(event)
+
+    return events
+
+
+# document.xml 가져오기
+def fetch_document_xml(rcept_no: str) -> Optional[str]:
+    params = {
+        "crtfc_key": DART_KEY,
+        "rcept_no": rcept_no,
+    }
+
+    try:
+        resp = requests.get(DOC_URL, params=params, timeout=20)
+        resp.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"[WARN] document.xml 요청 실패: rcept_no={rcept_no}, 이유={e}")
+        return None
+
+    raw = resp.content
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as z:
+            names = z.namelist()
+            xml_candidates = [n for n in names if n.lower().endswith(".xml")]
+            if not xml_candidates:
+                print(f"[WARN] ZIP 안에 xml 파일 없음: rcept_no={rcept_no}, files={names}")
+                return None
+
+            xml_name = xml_candidates[0]
+            xml_bytes = z.read(xml_name)
+
+        try:
+            xml_text = xml_bytes.decode("euc-kr")
+        except UnicodeDecodeError:
+            xml_text = xml_bytes.decode("utf-8", errors="ignore")
+
+        return xml_text
+
+    except zipfile.BadZipFile:
+        pass
+
+    try:
+        txt = raw.decode("euc-kr")
+    except UnicodeDecodeError:
+        txt = raw.decode("utf-8", errors="ignore")
+
+    if "오류가 발생하였습니다" in txt or "접수번호 오류" in txt:
+        print(f"document.xml 응답 내 에러 문구 감지: rcept_no={rcept_no}")
+        return None
+
+    return txt
+
+
+# 제3자배정 배정대상자 테이블 파싱
+def parse_third_party_allocation(xml_text: str) -> List[Dict[str, Any]]:
+
+    soup = BeautifulSoup(xml_text, "lxml-xml")
+
+    tg = soup.find("TABLE-GROUP", {"ACLASS": "THD_ASN_LST"})
+    if tg is None:
+        return []
+
+    results: List[Dict[str, Any]] = []
+
+    for tr in tg.find_all("TR"):
+        row: Dict[str, Any] = {}
+
+        for cell in tr.find_all(["TE", "TU"]):
+            acode = cell.get("ACODE")
+            text = normalize_text(cell.text)
+
+            if acode == "PART":
+                row["name"] = text
+            elif acode == "RLT":
+                row["relation"] = text
+            elif acode == "SLT_JDG":
+                row["reason"] = text
+            elif acode == "MNTH":
+                row["trade_history"] = text
+            elif acode == "ALL_CNT":
+                row["assigned_shares"] = text
+            elif acode == "ETC":
+                row["remark"] = text
+
+        # 의미 없는 행(헤더/합계 등) 제거
+        name = row.get("name", "")
+        if not name:
+            continue
+        if name in ("계", "합계"):
+            continue
+
+        results.append(row)
+
+    return results
+
+
+# 메인 파이프라인
+def main():
+    # 기존 결과 로드
+    results: List[Dict[str, Any]] = []
+    already_done_rcept: set[str] = set()
+
+    if os.path.exists(OUTPUT_PATH):
+        try:
+            with open(OUTPUT_PATH, "r", encoding="utf-8") as f:
+                results = json.load(f)
+            for rec in results:
+                rno = rec.get("event", {}).get("rcept_no")
+                if rno:
+                    already_done_rcept.add(rno)
+            print(f"기존 결과 {len(results)}개 불러옴 (이미 처리한 rcept_no {len(already_done_rcept)}개)")
+        except Exception:
+            print("기존 결과 읽기 실패 → 새로 시작합니다.")
+            results = []
+            already_done_rcept = set()
+
+    # 회사 리스트 로드
+    with open(COMPANY_FILE, "r", encoding="utf-8") as f:
+        companies = json.load(f)
+
+    total_corps = len(companies)
+    print(f"\n상장사 총 {total_corps}개 대상 (company_list_market.json 기준)\n")
+
+    # 메인 루프
+    for idx_c, comp in enumerate(companies, start=1):
+        corp_name = comp.get("name")
+        corp_code = comp.get("corp_code")
+
+        if not corp_code:
+            continue
+
+        print("\n" + "=" * 70)
+        print(f"({idx_c}/{total_corps}) {corp_name} ({corp_code})")
+        print("=" * 70)
+
+        found_any_for_corp = False
+
+        # 연도별로 piicDecsn 조회
+        for year in YEARS:
+            bgn_de = f"{year}0101"
+            end_de = f"{year}1231"
+
+            piic_list = fetch_piic_list(corp_code, bgn_de, end_de)
+            time.sleep(API_SLEEP_SEC)
+
+            if not piic_list:
+                continue
+
+            events = normalize_piic_events(piic_list)
+            total_cnt = len(events)
+            third_events = [e for e in events if e.get("third_party")]
+            third_cnt = len(third_events)
+
+            if total_cnt == 0:
+                continue
+
+            print(f"  - {year}: 전체 {total_cnt}건 (제3자배정 {third_cnt}건)")
+
+            if third_cnt == 0:
+                continue
+
+            found_any_for_corp = True
+
+            # 제3자배정 이벤트별로 document.xml 파싱
+            for ev in third_events:
+                rcept_no = ev.get("rcept_no")
+                if not rcept_no:
+                    continue
+
+                if rcept_no in already_done_rcept:
+                    continue
+
+                print(f"rcept_no={rcept_no}, 방법={ev.get('ic_mthn')}")
+                xml_text = fetch_document_xml(rcept_no)
+                time.sleep(API_SLEEP_SEC)
+
+                if not xml_text:
+                    print("→ document.xml 없음 / 에러로 스킵")
+                    continue
+
+                allocation_tables = parse_third_party_allocation(xml_text)
+                print(f"→ 배정대상자 {len(allocation_tables)}명 추출")
+
+                record = {
+                    "corp_code": corp_code,
+                    "corp_name": corp_name,
+                    "year": year,
+                    "event": {
+                        "rcept_no": rcept_no,
+                        "ic_mthn": ev.get("ic_mthn"),
+                        "third_party": ev.get("third_party"),
+                        "raw_event": ev,  
+                    },
+                    "allocation_tables": allocation_tables,
+                }
+
+                results.append(record)
+                already_done_rcept.add(rcept_no)
+
+                # 중간 저장
+                save_results_safely(results, OUTPUT_PATH)
+
+        if not found_any_for_corp:
+            print("→ 이 회사에서는 제3자배정 건이 발견되지 않았습니다.")
+
+    print(f"\n전체 완료! 제3자배정 이벤트 {len(results)}건이 {OUTPUT_PATH} 에 저장되었습니다.\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# ✨ feat #12 : 제3자배정 유상증자 이벤트 전체 파이프라인 구축

## 📌 요약

DART 공시 데이터를 기반으로  **제3자배정 유상증자 이벤트를 자동 수집하고 정제하여 구조화하는 전체 파이프라인**을 구현함

상장사 유상증자 공시에서 배정대상자(THD_ASN_LST) 테이블을 안정적으로 추출하여 그래프 DB에 활용 가능한 원천 데이터를 생성하는 것을 목표로 하였음

---

## 🧩 주요 변경 사항

### 1. `scan_all_listed_third_party_allocation.py`
제3자배정 유상증자 전체 스캔 파이프라인 추가
- 상장사 전체를 대상으로 piicDecsn API 연도별 조회
- "제3자배정" 방식 유상증자 이벤트 필터링
- 이벤트별 document.xml 자동 다운로드 및 파싱
- 배정대상자 테이블(ACLASS="THD_ASN_LST") 구조화
- 결과를 원천 데이터 JSON으로 저장

### 2.  `fetch_document_xml.py`
document.xml 안정적 수집
- euc-kr / utf-8 디코딩 fallback 처리
- 오류 응답 자동 감지
- 디버깅용 XML 저장 기능 지원

### 3.  `make_capital_increase_third_party_tables.py`
- piicDecsn 결과 기반 제3자배정 이벤트 후보만 추출
- 이후 allocation 파이프라인과 단계 분리 가능하도록 설계

### 4. `fill_capital_increase_allocation_tables`
  - 이벤트 목록 → allocation_tables 일괄 채우기
  - 합계/소계 등 노이즈 행 제거
  - 중단 후 재실행 가능

### 5. 후속 분석을 위한 관계 키워드 및 엣지 빌더 추가
- 제3자배정 공시의 relation / reason / remark 필드에 실제로 등장하는 값들을 분석하여  
  의미 없는 개인, 합계, 형식적 관계를 제거하고, 분석 가치가 있는 관계만 선별
- 기업, 펀드, 전략적 투자자 중심으로 그래프 DB에 투입 가능한 edge 데이터 생성

> `relation_keyword.py`  
> `build_capital_increase_edges_clean.py`

---

## ✏️ 리뷰 포인트
- 이후 진행 작업 : 배정대상자 ↔ 기업 ↔ 이벤트 그래프 DB 구성

## 🔍 결과물

- 제3자배정 이벤트별 배정대상자 리스트
- 배정 주식 수, 관계, 선정 경위 등 구조화 데이터
- 그래프 관계 분석에 바로 투입 가능한 JSON

